### PR TITLE
[Image Plugin] Fix MIME type and encoding

### DIFF
--- a/generic/imageplugin/imageplugin.cpp
+++ b/generic/imageplugin/imageplugin.cpp
@@ -272,7 +272,7 @@ void ImagePlugin::actionActivated()
 		pix = pix.scaled(MAX_SIZE, MAX_SIZE, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 	}
 	QBuffer b(&image);
-	pix.save(&b, mimeType.toAscii().constData());
+	pix.save(&b, mimeType.toLatin1().constData());
 	QString imageBase64(image.toBase64());
 	int length = image.length();
 	if(length > 61440) {


### PR DESCRIPTION
Allows to actually display images from clipboard and images with faulty extensions in clients strictly adhering to the claimed MIME type.
