### PR TITLE
imagepreviewplugin: include QWebFrame

### DIFF
--- a/generic/imagepreviewplugin/ScrollKeeper.cpp
+++ b/generic/imagepreviewplugin/ScrollKeeper.cpp
@@ -7,6 +7,7 @@
 
 #include "ScrollKeeper.h"
 #ifdef HAVE_WEBKIT
+#include <QWebFrame>
 #include <QWebView>
 #endif
 #ifdef HAVE_WEBENGINE


### PR DESCRIPTION
To fix build:
```
src/plugins/generic/imagepreviewplugin/ScrollKeeper.cpp:48:26: error: invalid use of incomplete type 'class QWebFrame'
  scrollPos_ = mainFrame_->scrollBarValue(Qt::Vertical);
                           ^~~~~~~~~~~~~~
```
This was broken by 146b1a5f38ea18a12bf23d989f27c1198cc6dac8.