### PR TITLE
[OMEMO] Add fallback message

### DIFF
--- a/generic/omemoplugin/src/omemo.cpp
+++ b/generic/omemoplugin/src/omemo.cpp
@@ -331,6 +331,12 @@ bool OMEMO::encryptMessage(const QString &ownJid, int account, QDomElement &xml,
         QDomElement encryption = xml.ownerDocument().createElementNS("urn:xmpp:eme:0", "encryption");
         encryption.setAttribute("namespace", k_omemoXmlns);
         xml.appendChild(encryption);
+
+        QDomElement fallbackBody = xml.ownerDocument().createElement("body");
+        fallbackBody.appendChild(xml.ownerDocument().createTextNode(
+            tr("You received a message encrypted with OMEMO but your client doesn't support OMEMO.")
+        ));
+        xml.appendChild(fallbackBody);
     }
 
     return true;


### PR DESCRIPTION
If a recipient has published device keys but the current client doesn't support OMEMO, it might not display an error or give any hint that there was such a message.

This is even worse when I recently messaged a PSI 1.5 user with OMEMO keys (made by other clients), and messages were not only completely suppressed but the client even has sent back message receipts.

Adding a fallback `<body/>` to the message addresses this and it's also the way most other clients with OMEMO support handle this.