### PR TITLE
[OMEMO] Remove the presence tracking hack for nicknames

### DIFF
--- a/generic/omemoplugin/src/omemoplugin.h
+++ b/generic/omemoplugin/src/omemoplugin.h
@@ -148,7 +148,6 @@ private:
     EventCreatingHost *           m_eventCreator      = nullptr;
     PsiAccountControllingHost *   m_accountController = nullptr;
     OptionAccessingHost *         m_optionHost        = nullptr;
-    QMap<QString, QString>        m_mucNicks;
 };
 }
 #endif // PSIOMEMO_OMEMOPLUGIN_H


### PR DESCRIPTION
Related to psi-im/psi#625, removes the presence tracking hack in favor of the new mucNick() function in the plugins API.