### PR TITLE
allow omemo to be disabled/enabled when not available

### DIFF
--- a/generic/omemoplugin/src/omemoplugin.cpp
+++ b/generic/omemoplugin/src/omemoplugin.cpp
@@ -519,8 +519,9 @@ void OMEMOPlugin::updateAction(int account, const QString &user)
         bool       isGroup   = action->property("isGroup").toBool();
         bool       available = isGroup ? m_omemo->isAvailableForGroup(account, ownJid, bareJid)
                                        : m_omemo->isAvailableForUser(account, bareJid);
-        bool       enabled   = available && m_omemo->isEnabledForUser(account, bareJid);
-        action->setEnabled(available);
+        bool       enabled   = m_omemo->isEnabledForUser(account, bareJid);
+        // Prevents user from changing OMEMO state
+        // action->setEnabled(available);
         action->setChecked(enabled);
         action->setProperty("jid", bareJid);
         action->setProperty("account", account);


### PR DESCRIPTION
Fix #54
Fix #57
Fix psi-im/psi#630

Allow users to disable OMEMO even if it is not available to solve issues involving OMEMO forcing encryption