### PR TITLE
otr: workaround to avoid crash on plugin unload

### DIFF
--- a/generic/otrplugin/src/otrinternal.cpp
+++ b/generic/otrplugin/src/otrinternal.cpp
@@ -89,7 +89,11 @@ OtrInternal::OtrInternal(psiotr::OtrCallback *callback, psiotr::OtrPolicy &polic
 
 //-----------------------------------------------------------------------------
 
-OtrInternal::~OtrInternal() { otrl_userstate_free(m_userstate); }
+OtrInternal::~OtrInternal() {
+    // FIXME workaround to avoid crash on gcry_sexp_release(privkey->privkey) inside of otrl_privkey_forget()
+    m_userstate->privkey_root = nullptr;
+    otrl_userstate_free(m_userstate);
+}
 
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Workaround for the #33
We just don't try to free the private keys leaving them in memory. This is not critical because anyway the memory will be cleared on the app exit.
