### PR TITLE
OTR plugin: remove message "Private keys need to be generated"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ This repository contains all Psi plugins which their developers prefer to mainta
 
 ## Installation
 
-Normally you don't need compile these plugins yourself: they are distributed together with main program (in special packages for your Linux distro, in installer or archive for Windows, in app bundle for macOS, etc.). But if you need to build plugins yourself see instructions below.
+Normally you don't need to compile these plugins yourself: they are distributed together with main program
+(in special packages for your Linux distro, in installer or archive for Windows, in app bundle for macOS, etc.).
+But if you need to build plugins yourself see instructions below.
 
 All plugins may be built separately using qmake or cmake or they may be built together using cmake.
 
@@ -30,15 +32,14 @@ make -j4
 make install DESTDIR="../installdir"
 # If necessary replace "../installdir" from command above to any path you need
 # or copy them manually from "../installdir".
-
 ```
 
 Some available configuration options:
 
-* -DBUILD_PLUGINS="${plugins}"	- set list of plugins to build or to not build
-* -DBUILD_DEV_PLUGINS="ON"	- enable build of some plugins from dev/ (disabled by default)
-* -DPLUGINS_PATH="psi/plugins"	- set suffix for installation path to plugins
-* -DPLUGINS_ROOT_DIR="${path}"	- set path to directory with `plugins.cmake` file
+* `-DBUILD_PLUGINS="${plugins}"` - set list of plugins to build or to not build
+* `-DBUILD_DEV_PLUGINS="ON"` - enable build of some plugins from dev/ (disabled by default)
+* `-DPLUGINS_PATH="psi/plugins"` - set suffix for installation path to plugins
+* `-DPLUGINS_ROOT_DIR="${path}"` - set path to directory with `plugins.cmake` file
 
 Option `-DPLUGINS_ROOT_DIR` should be used only when:
 

--- a/generic/otrplugin/src/otrinternal.cpp
+++ b/generic/otrplugin/src/otrinternal.cpp
@@ -516,22 +516,6 @@ void OtrInternal::create_privkey(const char *accountname, const char *protocol)
         return;
     }
 
-    QMessageBox qMB(QMessageBox::Question, QObject::tr("Confirm action"),
-                    QObject::tr("Private keys for account \"%1\" need to be generated. "
-                                "This takes quite some time (from a few seconds to a "
-                                "couple of minutes), and while you can use Psi in the "
-                                "meantime, all the messages will be sent unencrypted "
-                                "until keys are generated. You will be notified when "
-                                "this process finishes.\n"
-                                "\n"
-                                "Do you want to generate keys now?")
-                        .arg(m_callback->humanAccount(QString::fromUtf8(accountname))),
-                    QMessageBox::Yes | QMessageBox::No);
-
-    if (qMB.exec() != QMessageBox::Yes) {
-        return;
-    }
-
     void *newkeyp;
     if (otrl_privkey_generate_start(m_userstate, accountname, protocol, &newkeyp) == gcry_error(GPG_ERR_EEXIST)) {
         qWarning("libotr reports it's still generating a previous key while it shouldn't be");

--- a/generic/otrplugin/src/otrinternal.cpp
+++ b/generic/otrplugin/src/otrinternal.cpp
@@ -41,7 +41,6 @@
 #include <QString>
 #include <Qt>
 #include <QtConcurrentRun>
-#include <assert.h>
 
 //-----------------------------------------------------------------------------
 
@@ -63,24 +62,24 @@ OtrInternal::OtrInternal(psiotr::OtrCallback *callback, psiotr::OtrPolicy &polic
 
     OTRL_INIT;
     m_userstate                 = otrl_userstate_create();
-    m_uiOps.policy              = (*OtrInternal::cb_policy);
-    m_uiOps.create_privkey      = (*OtrInternal::cb_create_privkey);
-    m_uiOps.is_logged_in        = (*OtrInternal::cb_is_logged_in);
-    m_uiOps.inject_message      = (*OtrInternal::cb_inject_message);
-    m_uiOps.update_context_list = (*OtrInternal::cb_update_context_list);
-    m_uiOps.new_fingerprint     = (*OtrInternal::cb_new_fingerprint);
-    m_uiOps.write_fingerprints  = (*OtrInternal::cb_write_fingerprints);
-    m_uiOps.gone_secure         = (*OtrInternal::cb_gone_secure);
-    m_uiOps.gone_insecure       = (*OtrInternal::cb_gone_insecure);
-    m_uiOps.still_secure        = (*OtrInternal::cb_still_secure);
+    m_uiOps.policy              = OtrInternal::cb_policy;
+    m_uiOps.create_privkey      = OtrInternal::cb_create_privkey;
+    m_uiOps.is_logged_in        = OtrInternal::cb_is_logged_in;
+    m_uiOps.inject_message      = OtrInternal::cb_inject_message;
+    m_uiOps.update_context_list = OtrInternal::cb_update_context_list;
+    m_uiOps.new_fingerprint     = OtrInternal::cb_new_fingerprint;
+    m_uiOps.write_fingerprints  = OtrInternal::cb_write_fingerprints;
+    m_uiOps.gone_secure         = OtrInternal::cb_gone_secure;
+    m_uiOps.gone_insecure       = OtrInternal::cb_gone_insecure;
+    m_uiOps.still_secure        = OtrInternal::cb_still_secure;
 
     m_uiOps.max_message_size  = nullptr;
-    m_uiOps.account_name      = (*OtrInternal::cb_account_name);
-    m_uiOps.account_name_free = (*OtrInternal::cb_account_name_free);
+    m_uiOps.account_name      = OtrInternal::cb_account_name;
+    m_uiOps.account_name_free = OtrInternal::cb_account_name_free;
 
-    m_uiOps.handle_msg_event = (*OtrInternal::cb_handle_msg_event);
-    m_uiOps.handle_smp_event = (*OtrInternal::cb_handle_smp_event);
-    m_uiOps.create_instag    = (*OtrInternal::cb_create_instag);
+    m_uiOps.handle_msg_event = OtrInternal::cb_handle_msg_event;
+    m_uiOps.handle_smp_event = OtrInternal::cb_handle_smp_event;
+    m_uiOps.create_instag    = OtrInternal::cb_create_instag;
 
     otrl_privkey_read(m_userstate, QFile::encodeName(m_keysFile).constData());
     otrl_privkey_read_fingerprints(m_userstate, QFile::encodeName(m_fingerprintFile).constData(), nullptr, nullptr);

--- a/generic/otrplugin/src/psiotrclosure.cpp
+++ b/generic/otrplugin/src/psiotrclosure.cpp
@@ -404,9 +404,7 @@ PsiOtrClosure::PsiOtrClosure(const QString &account, const QString &contact, Otr
 
 PsiOtrClosure::~PsiOtrClosure()
 {
-    if (m_chatDlgMenu) {
-        delete m_chatDlgMenu;
-    }
+    delete m_chatDlgMenu;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
When starting an OTR conversations it first needed to generate a key.
This is annoying message, maybe years ago it the generation took minute(s) but today this happens immediately.
After generation it then shows the message "Keys have been generated. Thanks for your patience." which is also look useless. Maybe remove it too?